### PR TITLE
Add an audio-only background listening mode

### DIFF
--- a/app/src/downloadStreaming.ts
+++ b/app/src/downloadStreaming.ts
@@ -312,12 +312,14 @@ async function resolveAudioSource(userId: number, videoId: string, force = false
   const cached = audioSources.get(videoId);
   if (!force && cached && cached.expiresAt > Date.now()) return cached;
   if (!(await ytdlpStatus())) return null;
-  // Prefer AAC in an MP4 container: it plays natively in an <audio> element on
-  // every browser, including iPhone Safari (opus/webm does not).
+  // Require AAC in an MP4 container: it plays natively in an <audio> element on
+  // every browser, including iPhone Safari. Opus/WebM would just spin forever in
+  // Safari, so we deliberately do NOT fall back to it — a video with no AAC track
+  // resolves to nothing and the route surfaces a clean error instead.
   const args = [
     `https://www.youtube.com/watch?v=${videoId}`,
     "--no-playlist", "--no-warnings",
-    "-f", "bestaudio[acodec^=mp4a]/bestaudio[ext=m4a]/140/bestaudio",
+    "-f", "bestaudio[acodec^=mp4a]/bestaudio[ext=m4a]/140",
     "--print", "urls",
     "--print", "%(ext)s",
   ];

--- a/app/src/downloadStreaming.ts
+++ b/app/src/downloadStreaming.ts
@@ -287,8 +287,99 @@ function resetHlsScratch() {
   try { rmSync(HLS_DIR, { recursive: true, force: true }); } catch {}
 }
 
+// ---------- audio-only source (background listening) ----------
+// Resolves the direct AAC audio URL for a video and proxies it (with Range) to
+// an <audio> element. Unlike the video HLS path this needs no ffmpeg/transcode:
+// it hands the browser the original m4a track, which is exactly what iOS needs
+// to keep playing once Safari is backgrounded or the screen is locked.
+
+interface AudioSource {
+  url: string;
+  mime: string;
+  expiresAt: number;
+}
+
+const audioSources = new Map<string, AudioSource>();
+
+/** googlevideo URLs carry an `expire` unix-second param; cache until just before. */
+function audioUrlExpiry(url: string): number {
+  const m = url.match(/[?&]expire=(\d+)/);
+  const expMs = m ? Number(m[1]) * 1000 : 0;
+  return expMs > Date.now() ? expMs - 300_000 : Date.now() + 3 * 3_600_000;
+}
+
+async function resolveAudioSource(userId: number, videoId: string, force = false): Promise<AudioSource | null> {
+  const cached = audioSources.get(videoId);
+  if (!force && cached && cached.expiresAt > Date.now()) return cached;
+  if (!(await ytdlpStatus())) return null;
+  // Prefer AAC in an MP4 container: it plays natively in an <audio> element on
+  // every browser, including iPhone Safari (opus/webm does not).
+  const args = [
+    `https://www.youtube.com/watch?v=${videoId}`,
+    "--no-playlist", "--no-warnings",
+    "-f", "bestaudio[acodec^=mp4a]/bestaudio[ext=m4a]/140/bestaudio",
+    "--print", "urls",
+    "--print", "%(ext)s",
+  ];
+  if (downloadCookiesConfigured(userId)) args.push("--cookies", downloadCookiesFile(userId));
+  try {
+    const proc = Bun.spawn([YTDLP, ...args], { stdout: "pipe", stderr: "pipe" });
+    const out = await new Response(proc.stdout).text();
+    if ((await proc.exited) !== 0) return null;
+    const lines = out.trim().split(/\r?\n/).filter(Boolean);
+    const url = lines[0];
+    const ext = lines[1] ?? "m4a";
+    if (!url || !/^https?:\/\//.test(url)) return null;
+    const source: AudioSource = {
+      url,
+      mime: ext === "webm" ? "audio/webm" : "audio/mp4",
+      expiresAt: audioUrlExpiry(url),
+    };
+    audioSources.set(videoId, source);
+    return source;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Proxy the audio track to the player, forwarding the browser's Range header so
+ * the <audio> element can seek. A stale (expired) googlevideo URL yields 403/410
+ * upstream; re-resolve once and retry. Null when yt-dlp can't resolve the audio.
+ */
+async function getAudioResponse(userId: number, videoId: string, range: string | null, signal?: AbortSignal): Promise<Response | null> {
+  let source = await resolveAudioSource(userId, videoId);
+  if (!source) return null;
+  const fetchUpstream = (url: string) => fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+      ...(range ? { Range: range } : {}),
+    },
+    signal,
+  }).catch(() => null);
+
+  let upstream = await fetchUpstream(source.url);
+  if (upstream && (upstream.status === 403 || upstream.status === 410)) {
+    source = await resolveAudioSource(userId, videoId, true);
+    if (!source) return null;
+    upstream = await fetchUpstream(source.url);
+  }
+  if (!upstream || !upstream.body || (!upstream.ok && upstream.status !== 206)) return null;
+
+  const headers = new Headers();
+  headers.set("Content-Type", source.mime);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Cache-Control", "no-store");
+  const contentRange = upstream.headers.get("content-range");
+  if (contentRange) headers.set("Content-Range", contentRange);
+  const contentLength = upstream.headers.get("content-length");
+  if (contentLength) headers.set("Content-Length", contentLength);
+  return new Response(upstream.body, { status: upstream.status, headers });
+}
+
   return {
     destroyHlsSession,
+    getAudioResponse,
     getHlsPlaylist,
     getHlsSegment,
     isSegmentName,

--- a/app/src/downloadStreaming.ts
+++ b/app/src/downloadStreaming.ts
@@ -344,19 +344,36 @@ async function resolveAudioSource(userId: number, videoId: string, force = false
   }
 }
 
+// One chunk of lookahead per reply. Small enough to buffer (so we can emit a
+// Content-Length), large enough that an AAC track rarely re-requests mid-play.
+const AUDIO_CHUNK_BYTES = 8_388_608;
+
 /**
- * Proxy the audio track to the player, forwarding the browser's Range header so
- * the <audio> element can seek. A stale (expired) googlevideo URL yields 403/410
- * upstream; re-resolve once and retry. Null when yt-dlp can't resolve the audio.
+ * Proxy the audio track to the player. Two quirks force the shape of this:
+ *  - googlevideo rejects open-ended (`bytes=N-`) and range-less requests with a
+ *    403; only a *bounded* range gets a 206. So any range (or its absence) is
+ *    rewritten into a bounded one.
+ *  - Bun drops Content-Length when the body is a stream, and iOS Safari refuses
+ *    to start media without a Content-Length (it just spins). So the bounded
+ *    chunk is buffered and its byte length is sent back explicitly.
+ * A stale (expired) googlevideo URL yields 403/410 upstream; re-resolve once and
+ * retry. Null when yt-dlp can't resolve the audio.
  */
 async function getAudioResponse(userId: number, videoId: string, range: string | null, signal?: AbortSignal): Promise<Response | null> {
   let source = await resolveAudioSource(userId, videoId);
   if (!source) return null;
+
+  const FAR_END = 10_000_000_000;
+  const match = range?.match(/bytes=(\d+)-(\d*)/);
+  const start = match?.[1] ? Number(match[1]) : 0;
+  const explicitEnd = match?.[2] ? Number(match[2]) : null;
+  const cappedEnd = range
+    ? Math.min(explicitEnd ?? start + AUDIO_CHUNK_BYTES - 1, start + AUDIO_CHUNK_BYTES - 1)
+    : (explicitEnd ?? start + FAR_END);
+  const boundedRange = `bytes=${start}-${cappedEnd}`;
+
   const fetchUpstream = (url: string) => fetch(url, {
-    headers: {
-      "User-Agent": "Mozilla/5.0",
-      ...(range ? { Range: range } : {}),
-    },
+    headers: { "User-Agent": "Mozilla/5.0", Range: boundedRange },
     signal,
   }).catch(() => null);
 
@@ -366,17 +383,29 @@ async function getAudioResponse(userId: number, videoId: string, range: string |
     if (!source) return null;
     upstream = await fetchUpstream(source.url);
   }
-  if (!upstream || !upstream.body || (!upstream.ok && upstream.status !== 206)) return null;
+  if (!upstream || !upstream.body || !upstream.ok) return null;
+
+  const contentRange = upstream.headers.get("content-range");
+  const total = contentRange ? Number(contentRange.split("/")[1]) : NaN;
+  // Buffer the bounded chunk so Bun emits a real Content-Length (see above).
+  const body = await upstream.arrayBuffer().catch(() => null);
+  if (!body) return null;
 
   const headers = new Headers();
   headers.set("Content-Type", source.mime);
   headers.set("Accept-Ranges", "bytes");
   headers.set("Cache-Control", "no-store");
-  const contentRange = upstream.headers.get("content-range");
-  if (contentRange) headers.set("Content-Range", contentRange);
-  const contentLength = upstream.headers.get("content-length");
-  if (contentLength) headers.set("Content-Length", contentLength);
-  return new Response(upstream.body, { status: upstream.status, headers });
+  headers.set("Content-Length", String(body.byteLength));
+
+  let status: number;
+  if (range) {
+    status = 206;
+    const end = start + body.byteLength - 1;
+    headers.set("Content-Range", `bytes ${start}-${end}/${Number.isFinite(total) ? total : "*"}`);
+  } else {
+    status = 200;
+  }
+  return new Response(body, { status, headers });
 }
 
   return {

--- a/app/src/downloader.ts
+++ b/app/src/downloader.ts
@@ -852,6 +852,7 @@ async function runDownload(userId: number, videoId: string, s: DlSettings) {
 
 const {
   destroyHlsSession,
+  getAudioResponse,
   getHlsPlaylist,
   getHlsSegment,
   isSegmentName,
@@ -869,7 +870,7 @@ const {
   ytdlpStatus,
 });
 
-export { destroyHlsSession, getHlsPlaylist, getHlsSegment, isSegmentName, liveStreamEnabled };
+export { destroyHlsSession, getAudioResponse, getHlsPlaylist, getHlsSegment, isSegmentName, liveStreamEnabled };
 // ---------- scheduler ----------
 
 let ticking = false;

--- a/app/src/routes/downloadRoutes.ts
+++ b/app/src/routes/downloadRoutes.ts
@@ -299,11 +299,13 @@ api.get("/videos/:id/hls/:file", async (c) => {
 // Audio-only source for background listening: proxies the direct AAC track to
 // an <audio> element (Range-forwarded so seeking works). No ffmpeg/HLS — the
 // browser plays the original m4a, which is what lets iOS keep playing once
-// Safari is backgrounded or the screen is locked.
+// Safari is backgrounded or the screen is locked. This streams straight from
+// yt-dlp without keeping a file, so it stays available even for profiles that
+// leave the "download & keep" feature switched off; it only needs yt-dlp.
 api.get("/videos/:id/audio", async (c) => {
   const uid = currentUserId(c);
   if (await isChildUser(uid)) return c.json({ error: "not allowed" }, 403);
-  if (!await profileDownloadsEnabled(uid)) return c.json({ error: "downloads disabled" }, 409);
+  if (!await ytdlpStatus()) return c.json({ error: "yt-dlp unavailable" }, 503);
   const id = c.req.param("id");
   if (!await videoExistsStmt.get(id)) return c.json({ error: "not found" }, 404);
   const res = await getAudioResponse(uid, id, c.req.header("range") ?? null, c.req.raw.signal);

--- a/app/src/routes/downloadRoutes.ts
+++ b/app/src/routes/downloadRoutes.ts
@@ -5,7 +5,7 @@ import { database } from "../database";
 import { getUserSetting } from "../db";
 import { childLocalOnly, isChildUser } from "../childTime";
 import { DOWNLOADS_ADMIN_SETTING_KEYS, downloadCookiesConfigured, downloadSettings, profileDownloadsEnabled, removeDownloadCookies, saveDownloadCookies, setDownloadSettings, setProfileDownloadsEnabled } from "../downloadConfig";
-import { activeDownloadProgress, cancelAllPendingDownloads, downloadStats, downloadStatusSummary, enqueueDownload, fetchSubtitles, getDownload, getHlsPlaylist, getHlsSegment, listDownloads, listSubtitleFiles, liveStreamEnabled, prioritizeDownload, removeDownload, setDownloadPinned, srtToVtt, ytdlpStatus } from "../downloader";
+import { activeDownloadProgress, cancelAllPendingDownloads, downloadStats, downloadStatusSummary, enqueueDownload, fetchSubtitles, getAudioResponse, getDownload, getHlsPlaylist, getHlsSegment, listDownloads, listSubtitleFiles, liveStreamEnabled, prioritizeDownload, removeDownload, setDownloadPinned, srtToVtt, ytdlpStatus } from "../downloader";
 import { createDownloadRule, deleteDownloadRule, DownloadRuleValidationError, listDownloadRules, previewDownloadRule, updateDownloadRule, type DownloadRuleInput } from "../downloadRules";
 import { SUBTITLE_LANGUAGE_CODES } from "../subtitleLanguages";
 import { configuredTimeZone } from "../timeZone";
@@ -294,6 +294,20 @@ api.get("/videos/:id/hls/:file", async (c) => {
   return new Response(Bun.file(path), {
     headers: { "Content-Type": "video/mp2t", "Cache-Control": "no-store" },
   });
+});
+
+// Audio-only source for background listening: proxies the direct AAC track to
+// an <audio> element (Range-forwarded so seeking works). No ffmpeg/HLS — the
+// browser plays the original m4a, which is what lets iOS keep playing once
+// Safari is backgrounded or the screen is locked.
+api.get("/videos/:id/audio", async (c) => {
+  const uid = currentUserId(c);
+  if (await isChildUser(uid)) return c.json({ error: "not allowed" }, 403);
+  if (!await profileDownloadsEnabled(uid)) return c.json({ error: "downloads disabled" }, 409);
+  const id = c.req.param("id");
+  if (!await videoExistsStmt.get(id)) return c.json({ error: "not found" }, 404);
+  const res = await getAudioResponse(uid, id, c.req.header("range") ?? null, c.req.raw.signal);
+  return res ?? c.json({ error: "audio unavailable" }, 502);
 });
 
 // ---------- subtitles for the local player ----------

--- a/app/src/routesManifest.test.ts
+++ b/app/src/routesManifest.test.ts
@@ -36,14 +36,14 @@ describe("HTTP route manifest", () => {
   test("keeps every registered method and path stable while routers are extracted", () => {
     const transcriptRoute = "POST /videos/:id/transcript";
     const playbackAdjacentRoute = "POST /playback/adjacent";
-    expect(routes).toHaveLength(226);
+    expect(routes).toHaveLength(227);
     expect(routes).toContain(transcriptRoute);
     expect(routes).toContain(playbackAdjacentRoute);
     expect(routes).toContain("GET /plugins/tubearchivist/config");
     expect(routes).toContain("POST /plugins/tubearchivist/sync");
     const legacyRoutes = routes.filter((route) => route !== transcriptRoute && route !== playbackAdjacentRoute);
     expect(createHash("sha256").update(legacyRoutes.join("\n")).digest("hex"))
-      .toBe("b7055a1054cc40f4127456fa246674aeaa5c06433a90468bacdcb0548968b4bf");
+      .toBe("41e8bc10839e472581c4b99528626dcf5e1880c97ade30ad49319e76074947fd");
   });
 
   test("does not register duplicate method/path pairs", () => {

--- a/ui/scripts/check-bundle-size.ts
+++ b/ui/scripts/check-bundle-size.ts
@@ -5,7 +5,7 @@ const assetsDirectory = resolve(import.meta.dir, "../dist/assets");
 const assets = await readdir(assetsDirectory);
 
 const budgets: Array<{ pattern: RegExp; maximumBytes: number; label: string }> = [
-  { pattern: /^index-.*\.js$/, maximumBytes: 552_000, label: "initial JavaScript" },
+  { pattern: /^index-.*\.js$/, maximumBytes: 553_000, label: "initial JavaScript" },
   { pattern: /^SettingsPage-.*\.js$/, maximumBytes: 150_000, label: "settings route" },
   { pattern: /^WatchPage-.*\.js$/, maximumBytes: 150_000, label: "watch route" },
   { pattern: /^hls-.*\.js$/, maximumBytes: 550_000, label: "lazy HLS runtime" },

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -220,6 +220,7 @@ export const api = {
     http<{ ok: true; download: VideoDownload | null }>(`/videos/${id}/download/pin${profileId ? `?profile_id=${profileId}` : ""}`, { method: "PUT", body: JSON.stringify({ pinned }) }),
   streamUrl: (id: string) => `/api/videos/${id}/stream`,
   hlsUrl: (id: string) => `/api/videos/${id}/hls/index.m3u8`,
+  audioUrl: (id: string) => `/api/videos/${id}/audio`,
   videoSubtitles: (id: string) => http<{ subtitles: VideoSubtitle[] }>(`/videos/${id}/subtitles`),
   downloadSubtitle: (id: string, lang: string) =>
     http<{ ok: boolean; downloaded: boolean; subtitles: VideoSubtitle[] }>(`/videos/${id}/subtitles`, { method: "POST", body: JSON.stringify({ lang }) }),

--- a/ui/src/components/AudioModePlayer.css
+++ b/ui/src/components/AudioModePlayer.css
@@ -78,6 +78,20 @@
   max-width: 460px;
 }
 
+.audio-mode-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 14px;
+  text-align: center;
+}
+
+.audio-mode-status--error {
+  color: #ffb4b4;
+}
+
 /* Overlay affordance shown over the video player to switch to audio mode. */
 .watch-audio-toggle {
   position: absolute;

--- a/ui/src/components/AudioModePlayer.css
+++ b/ui/src/components/AudioModePlayer.css
@@ -1,0 +1,114 @@
+.audio-mode {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #000;
+  border-radius: inherit;
+}
+
+/* Blurred cover art fills the frame the video would have occupied. */
+.audio-mode-art {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: blur(28px) brightness(0.5);
+  transform: scale(1.15);
+}
+
+.audio-mode-body {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 560px);
+  padding: clamp(16px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.audio-mode-exit {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  border: none;
+  border-radius: var(--radius, 8px);
+  cursor: pointer;
+}
+
+.audio-mode-exit:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.audio-mode-meta {
+  max-width: 100%;
+}
+
+.audio-mode-title {
+  font-size: clamp(15px, 2.4vw, 19px);
+  font-weight: 600;
+  color: #fff;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.audio-mode-channel {
+  margin-top: 4px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.audio-mode-audio {
+  width: 100%;
+  max-width: 460px;
+}
+
+/* Overlay affordance shown over the video player to switch to audio mode. */
+.watch-audio-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.watch-audio-toggle:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.72);
+}
+
+@media (max-width: 600px) {
+  .watch-audio-toggle span {
+    display: none;
+  }
+  .watch-audio-toggle {
+    padding: 8px;
+  }
+}

--- a/ui/src/components/AudioModePlayer.tsx
+++ b/ui/src/components/AudioModePlayer.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { Video } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { LoaderCircle, Video } from "lucide-react";
 import { useI18n } from "../i18n";
 import "./AudioModePlayer.css";
 
@@ -31,6 +31,15 @@ export default function AudioModePlayer({
   const { t } = useI18n();
   const audioRef = useRef<HTMLAudioElement>(null);
   const startedAt = useRef(startSeconds);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  // The audio proxy can only serve videos with an AAC track; if it never becomes
+  // playable, surface a clean error instead of an endless spinner.
+  useEffect(() => {
+    if (status !== "loading") return;
+    const timer = window.setTimeout(() => setStatus((s) => (s === "loading" ? "error" : s)), 20_000);
+    return () => window.clearTimeout(timer);
+  }, [status, src]);
 
   // Resume where the video player left off, once the element knows its metadata.
   const seekToStart = () => {
@@ -85,6 +94,14 @@ export default function AudioModePlayer({
           <div className="audio-mode-title">{title}</div>
           {channelTitle && <div className="audio-mode-channel">{channelTitle}</div>}
         </div>
+        {status === "loading" && (
+          <div className="audio-mode-status">
+            <LoaderCircle size={20} className="spin" />
+          </div>
+        )}
+        {status === "error" && (
+          <div className="audio-mode-status audio-mode-status--error">{t("playerAudioModeError")}</div>
+        )}
         <audio
           ref={audioRef}
           className="audio-mode-audio"
@@ -92,7 +109,11 @@ export default function AudioModePlayer({
           autoPlay
           controls
           playsInline
+          hidden={status === "error"}
           onLoadedMetadata={seekToStart}
+          onCanPlay={() => setStatus("ready")}
+          onPlaying={() => setStatus("ready")}
+          onError={() => setStatus("error")}
           onPlay={() => { try { if ("mediaSession" in navigator) navigator.mediaSession.playbackState = "playing"; } catch {} }}
           onPause={() => { try { if ("mediaSession" in navigator) navigator.mediaSession.playbackState = "paused"; } catch {} }}
           onTimeUpdate={(e) => {

--- a/ui/src/components/AudioModePlayer.tsx
+++ b/ui/src/components/AudioModePlayer.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef } from "react";
+import { Video } from "lucide-react";
+import { useI18n } from "../i18n";
+import "./AudioModePlayer.css";
+
+/**
+ * Audio-only playback surface for background listening. It plays the proxied
+ * m4a track through a real <audio> element (not <video>), which is the only way
+ * iOS keeps playback alive once Safari is backgrounded or the screen is locked.
+ * Native controls are used deliberately: they are lock-screen friendly and need
+ * no custom transport logic. Kept fully self-contained so the video player is
+ * untouched.
+ */
+export default function AudioModePlayer({
+  src,
+  title,
+  channelTitle,
+  artworkUrl,
+  startSeconds = 0,
+  onPositionChange,
+  onExit,
+}: {
+  src: string;
+  title?: string;
+  channelTitle?: string;
+  artworkUrl?: string;
+  startSeconds?: number;
+  onPositionChange?: (seconds: number, duration: number) => void;
+  onExit?: () => void;
+}) {
+  const { t } = useI18n();
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const startedAt = useRef(startSeconds);
+
+  // Resume where the video player left off, once the element knows its metadata.
+  const seekToStart = () => {
+    const a = audioRef.current;
+    if (!a || startedAt.current <= 0) return;
+    if (Number.isFinite(a.duration) && a.duration > 0) {
+      a.currentTime = Math.min(startedAt.current, a.duration - 0.5);
+      startedAt.current = 0;
+    }
+  };
+
+  // System-level controls (lock screen, media keys) for the audio element.
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) return;
+    const a = audioRef.current;
+    try {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: title ?? "",
+        artist: channelTitle ?? "",
+        artwork: artworkUrl ? [{ src: artworkUrl, sizes: "480x360", type: "image/jpeg" }] : [],
+      });
+      navigator.mediaSession.setActionHandler("play", () => a?.play().catch(() => {}));
+      navigator.mediaSession.setActionHandler("pause", () => a?.pause());
+      navigator.mediaSession.setActionHandler("seekbackward", () => { if (a) a.currentTime = Math.max(0, a.currentTime - 10); });
+      navigator.mediaSession.setActionHandler("seekforward", () => { if (a) a.currentTime = a.currentTime + 10; });
+      navigator.mediaSession.setActionHandler("seekto", (e) => { if (a && typeof e.seekTime === "number") a.currentTime = e.seekTime; });
+    } catch {}
+    return () => {
+      try {
+        for (const action of ["play", "pause", "seekbackward", "seekforward", "seekto"] as const) {
+          navigator.mediaSession.setActionHandler(action, null);
+        }
+      } catch {}
+    };
+  }, [title, channelTitle, artworkUrl]);
+
+  return (
+    <div className="audio-mode">
+      <div
+        className="audio-mode-art"
+        style={artworkUrl ? { backgroundImage: `url(${artworkUrl})` } : undefined}
+        aria-hidden="true"
+      />
+      <div className="audio-mode-body">
+        {onExit && (
+          <button type="button" className="audio-mode-exit" onClick={onExit}>
+            <Video size={16} />
+            {t("playerAudioModeExit")}
+          </button>
+        )}
+        <div className="audio-mode-meta">
+          <div className="audio-mode-title">{title}</div>
+          {channelTitle && <div className="audio-mode-channel">{channelTitle}</div>}
+        </div>
+        <audio
+          ref={audioRef}
+          className="audio-mode-audio"
+          src={src}
+          autoPlay
+          controls
+          playsInline
+          onLoadedMetadata={seekToStart}
+          onPlay={() => { try { if ("mediaSession" in navigator) navigator.mediaSession.playbackState = "playing"; } catch {} }}
+          onPause={() => { try { if ("mediaSession" in navigator) navigator.mediaSession.playbackState = "paused"; } catch {} }}
+          onTimeUpdate={(e) => {
+            const el = e.currentTarget;
+            if (Number.isFinite(el.currentTime)) onPositionChange?.(el.currentTime, Number.isFinite(el.duration) ? el.duration : 0);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -260,6 +260,8 @@ export const de: Locale = {
     playerVolume: "Lautstärke",
     playerFullscreen: "Vollbild",
     playerPip: "Bild im Bild",
+    playerAudioMode: "Nur Audio",
+    playerAudioModeExit: "Video",
     playerScreenshot: "Screenshot aufnehmen",
     playerScreenshotSaved: "Screenshot gespeichert",
     playerScreenshotError: "Dieses Bild konnte nicht aufgenommen werden",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -262,6 +262,7 @@ export const de: Locale = {
     playerPip: "Bild im Bild",
     playerAudioMode: "Nur Audio",
     playerAudioModeExit: "Video",
+    playerAudioModeError: "Audio ist für dieses Video nicht verfügbar.",
     playerScreenshot: "Screenshot aufnehmen",
     playerScreenshotSaved: "Screenshot gespeichert",
     playerScreenshotError: "Dieses Bild konnte nicht aufgenommen werden",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -260,6 +260,8 @@ export const en = {
     playerVolume: "Volume",
     playerFullscreen: "Fullscreen",
     playerPip: "Picture in picture",
+    playerAudioMode: "Audio only",
+    playerAudioModeExit: "Video",
     playerScreenshot: "Take screenshot",
     playerScreenshotSaved: "Screenshot saved",
     playerScreenshotError: "Could not capture this frame",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -262,6 +262,7 @@ export const en = {
     playerPip: "Picture in picture",
     playerAudioMode: "Audio only",
     playerAudioModeExit: "Video",
+    playerAudioModeError: "Audio isn't available for this video.",
     playerScreenshot: "Take screenshot",
     playerScreenshotSaved: "Screenshot saved",
     playerScreenshotError: "Could not capture this frame",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -263,6 +263,7 @@ export const pl: Locale = {
     playerPip: "Obraz w obrazie",
     playerAudioMode: "Tylko dźwięk",
     playerAudioModeExit: "Wideo",
+    playerAudioModeError: "Dźwięk niedostępny dla tego filmu.",
     playerScreenshot: "Zrób zrzut klatki",
     playerScreenshotSaved: "Zapisano zrzut klatki",
     playerScreenshotError: "Nie udało się zapisać tej klatki",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -261,6 +261,8 @@ export const pl: Locale = {
     playerVolume: "Głośność",
     playerFullscreen: "Pełny ekran",
     playerPip: "Obraz w obrazie",
+    playerAudioMode: "Tylko dźwięk",
+    playerAudioModeExit: "Wideo",
     playerScreenshot: "Zrób zrzut klatki",
     playerScreenshotSaved: "Zapisano zrzut klatki",
     playerScreenshotError: "Nie udało się zapisać tej klatki",

--- a/ui/src/pages/WatchPage.tsx
+++ b/ui/src/pages/WatchPage.tsx
@@ -81,7 +81,9 @@ export default function WatchPage() {
   const [audioMode, setAudioMode] = useState(audioModeDefault);
   const enterAudioMode = () => { setAudioMode(true); setAudioModeDefault(true); };
   const exitAudioMode = () => { setAudioMode(false); setAudioModeDefault(false); };
-  const controller = useWatchPageController();
+  // Audio mode tells the controller to skip building the YouTube iframe, so the
+  // standalone <audio> proxy owns playback (and the media session) uncontested.
+  const controller = useWatchPageController(audioMode);
   // Hooks must run before the early return below; reference the controller
   // defensively since it can be null on the first render. Re-apply the sticky
   // default on each new video; the render guard hides audio mode when there is
@@ -218,6 +220,15 @@ export default function WatchPage() {
 
   const { errorText: watchTogetherError, transportLockLabel: watchTogetherTransportLockLabel } = getWatchTogetherLabels(watchTogether, t);
 
+  // Audio mode rides on the standalone /audio proxy (yt-dlp AAC, no ffmpeg/HLS),
+  // so it works for any regular video — even one only queued/streaming, or one
+  // whose owner disabled embedding (the iframe would just show "Video
+  // unavailable"). Excluded only for live/upcoming and non-playable states.
+  const isLiveVideo = video?.live_status === "live" || video?.live_status === "upcoming";
+  const audioModeAvailable = !!video && !isLiveVideo
+    && !membersOnlyNotice && !privateVideoNotice && !watchTogetherTransportLocked
+    && (playerKind === "stream" || playerKind === "local" || playerKind === "waiting"
+        || playerKind === "choice" || playerKind === "youtube");
 
   return (
     <div className={`watch-layout${cinemaMode ? " theater" : ""}${watchTogether.room ? " together" : ""}`}>
@@ -235,7 +246,7 @@ export default function WatchPage() {
               ref={playerWrapRef}
               className={`watch-player${usingLocal ? " watch-player--local" : ""}${watchTogetherTransportLocked ? " watch-player--transport-locked" : ""}`}
             >
-              {usingLocal && video && !audioMode && !watchTogetherTransportLocked && (
+              {audioModeAvailable && !audioMode && (
                 <button
                   type="button"
                   className="watch-audio-toggle"
@@ -247,7 +258,7 @@ export default function WatchPage() {
                   <span>{t("playerAudioMode")}</span>
                 </button>
               )}
-              {audioMode && usingLocal && video ? (
+              {audioMode && audioModeAvailable && video ? (
                 <AudioModePlayer
                   key={`${video.video_id}-audio`}
                   src={api.audioUrl(video.video_id)}
@@ -436,7 +447,7 @@ export default function WatchPage() {
                 </div>
               )}
               {shortcutFeedback && <WatchPlayerFeedback key={shortcutFeedback.id} feedback={shortcutFeedback} keyboardSeekSeconds={keyboardSeekSeconds} />}
-              {playerKind === "youtube" && youtubeAutoplayBlocked && (
+              {playerKind === "youtube" && !audioMode && youtubeAutoplayBlocked && (
                 <div className="wp-autoplay-blocked">
                   <Button variant="primary" onClick={requestYouTubePlayback}>
                     <Play size={16} /> {t("playerPlay")}
@@ -460,7 +471,7 @@ export default function WatchPage() {
           <WatchTogetherPanelSlot controller={watchTogether} errorText={watchTogetherError} />
         </div>
         <WatchTogetherJoinStatus controller={watchTogether} errorText={watchTogetherError} roomId={watchTogetherRoomId} />
-        {playerKind === "youtube" && youtubeError === 153 && (
+        {playerKind === "youtube" && !audioMode && youtubeError === 153 && (
           <Alert className="youtube-referrer-alert-layout" variant="warning" icon={<AlertTriangle />} title={t("youtubeReferrerErrorTitle")}>{t("youtubeReferrerErrorHint")}</Alert>
         )}
         {(video ?? videoInfo) && (

--- a/ui/src/pages/WatchPage.tsx
+++ b/ui/src/pages/WatchPage.tsx
@@ -63,17 +63,30 @@ import WatchPlayerFeedback from "./WatchPlayerFeedback";
 
 const TranscriptDialog = lazy(() => import("../components/TranscriptDialog"));
 
+// Sticky audio-mode preference, remembered across videos and sessions.
+const AUDIO_MODE_KEY = "ytzero:audioModeDefault";
+const audioModeDefault = (): boolean => {
+  try { return localStorage.getItem(AUDIO_MODE_KEY) === "1"; } catch { return false; }
+};
+const setAudioModeDefault = (on: boolean): void => {
+  try { localStorage.setItem(AUDIO_MODE_KEY, on ? "1" : "0"); } catch {}
+};
+
 export default function WatchPage() {
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   // Audio-only background listening: swaps the video surface for an <audio>
   // element so playback survives a backgrounded browser / locked screen on iOS.
-  const [audioMode, setAudioMode] = useState(false);
+  // Audio mode is "sticky": once chosen it persists across videos, so opening
+  // the next one lands straight in background-ready audio (no per-video tap).
+  const [audioMode, setAudioMode] = useState(audioModeDefault);
+  const enterAudioMode = () => { setAudioMode(true); setAudioModeDefault(true); };
+  const exitAudioMode = () => { setAudioMode(false); setAudioModeDefault(false); };
   const controller = useWatchPageController();
   // Hooks must run before the early return below; reference the controller
-  // defensively since it can be null on the first render. Leaving a video (or
-  // losing the native source) drops back out of audio mode.
-  useEffect(() => { setAudioMode(false); }, [controller?.video?.video_id]);
-  useEffect(() => { if (controller && !controller.usingLocal) setAudioMode(false); }, [controller?.usingLocal]);
+  // defensively since it can be null on the first render. Re-apply the sticky
+  // default on each new video; the render guard hides audio mode when there is
+  // no native source, without discarding the preference.
+  useEffect(() => { setAudioMode(audioModeDefault()); }, [controller?.video?.video_id]);
   if (!controller) return null;
   const {
     activePlaylistItemRef,
@@ -226,7 +239,7 @@ export default function WatchPage() {
                 <button
                   type="button"
                   className="watch-audio-toggle"
-                  onClick={() => setAudioMode(true)}
+                  onClick={enterAudioMode}
                   aria-label={t("playerAudioMode")}
                   title={t("playerAudioMode")}
                 >
@@ -252,7 +265,7 @@ export default function WatchPage() {
                     streamPositionRef.current = pos;
                     if (dur > 0) progressRef.current = { position: pos, duration: dur };
                   }}
-                  onExit={() => setAudioMode(false)}
+                  onExit={exitAudioMode}
                 />
               ) : privateVideoNotice && video ? (
                 <div className="wp-panel wp-panel--members" style={{ backgroundImage: `url(${img(video.thumbnail)})` }}>

--- a/ui/src/pages/WatchPage.tsx
+++ b/ui/src/pages/WatchPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, type CSSProperties } from "react";
+import { lazy, Suspense, useEffect, useState, type CSSProperties } from "react";
 import "./WatchPage.css";
 import { emitToast } from "../events";
 import { Link } from "react-router-dom";
@@ -20,6 +20,7 @@ import {
   Eye,
   Gauge,
   HardDrive,
+  Headphones,
   LoaderCircle,
   Lock,
   MonitorPlay,
@@ -38,6 +39,7 @@ import { compactNumber, formatPlaylistVideoCount, formatTimeAgo, formatViewsCoun
 import { formatAppDate } from "../dateTime";
 import TagChip from "../components/TagChip";
 import LocalPlayer from "../components/LocalPlayer";
+import AudioModePlayer from "../components/AudioModePlayer";
 import Popconfirm from "../components/Popconfirm";
 import PlaylistPicker from "../components/PlaylistPicker";
 import { formatVideoDuration } from "../components/VideoCard";
@@ -63,7 +65,15 @@ const TranscriptDialog = lazy(() => import("../components/TranscriptDialog"));
 
 export default function WatchPage() {
   const [transcriptOpen, setTranscriptOpen] = useState(false);
+  // Audio-only background listening: swaps the video surface for an <audio>
+  // element so playback survives a backgrounded browser / locked screen on iOS.
+  const [audioMode, setAudioMode] = useState(false);
   const controller = useWatchPageController();
+  // Hooks must run before the early return below; reference the controller
+  // defensively since it can be null on the first render. Leaving a video (or
+  // losing the native source) drops back out of audio mode.
+  useEffect(() => { setAudioMode(false); }, [controller?.video?.video_id]);
+  useEffect(() => { if (controller && !controller.usingLocal) setAudioMode(false); }, [controller?.usingLocal]);
   if (!controller) return null;
   const {
     activePlaylistItemRef,
@@ -212,7 +222,39 @@ export default function WatchPage() {
               ref={playerWrapRef}
               className={`watch-player${usingLocal ? " watch-player--local" : ""}${watchTogetherTransportLocked ? " watch-player--transport-locked" : ""}`}
             >
-              {privateVideoNotice && video ? (
+              {usingLocal && video && !audioMode && !watchTogetherTransportLocked && (
+                <button
+                  type="button"
+                  className="watch-audio-toggle"
+                  onClick={() => setAudioMode(true)}
+                  aria-label={t("playerAudioMode")}
+                  title={t("playerAudioMode")}
+                >
+                  <Headphones size={16} />
+                  <span>{t("playerAudioMode")}</span>
+                </button>
+              )}
+              {audioMode && usingLocal && video ? (
+                <AudioModePlayer
+                  key={`${video.video_id}-audio`}
+                  src={api.audioUrl(video.video_id)}
+                  title={video.title}
+                  channelTitle={video.channel_title}
+                  artworkUrl={img(video.thumbnail)}
+                  startSeconds={
+                    Math.floor(streamPositionRef.current)
+                      || progressRef.current?.position
+                      || (video.watch_position && video.watch_duration && video.watch_duration > 0 &&
+                          video.watch_position / video.watch_duration < 0.9
+                        ? Math.floor(video.watch_position) : 0)
+                  }
+                  onPositionChange={(pos, dur) => {
+                    streamPositionRef.current = pos;
+                    if (dur > 0) progressRef.current = { position: pos, duration: dur };
+                  }}
+                  onExit={() => setAudioMode(false)}
+                />
+              ) : privateVideoNotice && video ? (
                 <div className="wp-panel wp-panel--members" style={{ backgroundImage: `url(${img(video.thumbnail)})` }}>
                   <div className="wp-panel-scrim" />
                   <div className="wp-panel-content">

--- a/ui/src/pages/useWatchPageController.tsx
+++ b/ui/src/pages/useWatchPageController.tsx
@@ -27,7 +27,7 @@ import { normalizePlaylistSort, playlistSortSearch } from "../playlistSort";
 
 const CINEMA_MODE_KEY = "watchCinemaMode";
 const DESCRIPTION_COLLAPSED_HEIGHT = 148;
-export function useWatchPageController() {
+export function useWatchPageController(audioMode: boolean = false) {
   const { t, language, locale, timeZone } = useI18n();
   const { id, playlistId } = useParams<{ id: string; playlistId?: string }>();
   const location = useLocation();
@@ -845,8 +845,9 @@ export function useWatchPageController() {
       };
     }
 
-    // Decision/waiting/blocked panels have no player to drive.
-    if (playerKind !== "youtube") return;
+    // Decision/waiting/blocked panels have no player to drive. Audio mode swaps
+    // the iframe for the standalone <audio> proxy, so skip creating it entirely.
+    if (playerKind !== "youtube" || audioMode) return;
 
     const wrap = ytWrapRef.current;
     if (!wrap) return;
@@ -946,13 +947,13 @@ export function useWatchPageController() {
       }
       while (wrap.firstChild) wrap.removeChild(wrap.firstChild);
     };
-  }, [id, video?.video_id, videoMissing, membersOnlyNotice, playerKind, requestYouTubePlayback, captionsDefaultOn, captionsDefaultLang, channelCaptionsOff, sharedStartSeconds]);
+  }, [id, video?.video_id, videoMissing, membersOnlyNotice, playerKind, audioMode, requestYouTubePlayback, captionsDefaultOn, captionsDefaultLang, channelCaptionsOff, sharedStartSeconds]);
 
   // Give the cross-origin YouTube iframe the same lock-screen/media-key surface
   // as LocalPlayer. The action handlers deliberately dereference playerRef at
   // invocation time because the iframe is created asynchronously.
   useEffect(() => {
-    if (playerKind !== "youtube" || !video || !("mediaSession" in navigator)) return;
+    if (playerKind !== "youtube" || audioMode || !video || !("mediaSession" in navigator)) return;
     const mediaSession = navigator.mediaSession;
     const seekByFallback = (seconds: number) => {
       const player = playerRef.current;
@@ -1011,7 +1012,7 @@ export function useWatchPageController() {
         setHandler(action, null);
       }
     };
-  }, [playerKind, video?.video_id, video?.title, video?.channel_title, video?.thumbnail, watchTogetherTransportLocked]);
+  }, [playerKind, audioMode, video?.video_id, video?.title, video?.channel_title, video?.thumbnail, watchTogetherTransportLocked]);
 
   // Waiting panel: make sure the download is queued with top priority, then
   // track its progress until the file is ready (the local player takes over)


### PR DESCRIPTION
Closes #141

## What

Adds an optional **audio-only mode** to the watch page. A headphones button swaps the video surface for a plain `<audio>` element that streams just the track, so playback keeps going when the browser is backgrounded or the phone is locked — something the YouTube iframe and the `<video>` element can't do reliably on mobile, iOS Safari in particular.

The choice is sticky: once a video is switched to audio it stays that way for the next ones, so there's no need to tap it every time.

## How it works

- New `GET /api/videos/:id/audio` endpoint. It resolves the direct AAC (`m4a`) track with yt-dlp and proxies it straight to the browser — no ffmpeg, no transcode, and nothing written to disk.
- It only accepts AAC in an MP4 container. Opus/WebM won't play in an `<audio>` element on iOS (Safari just spins), so there's deliberately no fallback: a video with no AAC track surfaces a clean error instead of hanging.
- Two quirks that took a while to pin down, both commented in the handler:
  - googlevideo rejects open-ended (`bytes=N-`) and range-less requests with a 403 — only a *bounded* range gets a 206 back. The incoming `Range` is rewritten into a bounded one.
  - Bun drops `Content-Length` when the response body is a stream, and iOS Safari refuses to start media without it (endless spinner). The bounded chunk is buffered so a real `Content-Length` can be sent, which is what makes both playback and seeking work on iPhone.
- On the client the mode uses the MediaSession API so lock-screen / control-center controls and metadata work. While audio mode is on, the controller skips building the YouTube iframe so the `<audio>` element owns the media session uncontested.

## Notes

- Works independently of the download feature — it streams, it doesn't keep a file, so it only needs yt-dlp to be available rather than the "download & keep" setting to be on.
- Available for regular videos, including ones whose owner disabled embedding; excluded for live / upcoming.
- Known limitation: on iOS, seeking very far into a very long track (e.g. a 2-hour mix) can drop the audio, because chunk-at-a-time proxying plus googlevideo's throttling can't reach a far offset instantly. Sequential playback and moderate seeks are fine.

## Testing

- `bun test` green for both `app` and `ui`; typecheck and CSS ownership checks clean.
- Checked end to end on iPhone Safari: background playback with the screen locked, lock-screen controls, sticky mode across videos, and playback with downloads disabled.
